### PR TITLE
AwesomeForm / AwesomeCrud Quand display une page de détail, puis qu'o…

### DIFF
--- a/src/components/crud/AwesomeForm.vue
+++ b/src/components/crud/AwesomeForm.vue
@@ -1085,8 +1085,7 @@ export default {
 
     cancel() {
       //eslint-disable-next-line
-      this.closeModal();
-      this.$emit("cancel", null, { context: this.mode });
+      this.$emit("cancel", this.item, { context: this.mode });
     },
 
     close() {


### PR DESCRIPTION
…n édit et ensuite on cancel, on revient bien sur la vue de détail, mais elle est vide de contenu, et l'url ne contient pas l'id du formulaire

https://trello.com/c/zhG0n5Qu/38-awesomeform-awesomecrud-quand-display-une-page-de-d%C3%A9tail-puis-quon-%C3%A9dit-et-ensuite-on-cancel-on-revient-bien-sur-la-vue-de-d%C3%A9tai

* Come back to view detail with infos