### PR TITLE
AwesomeForm: Edit mode list of items do not show

### DIFF
--- a/examples/fixtures/user.js
+++ b/examples/fixtures/user.js
@@ -54,7 +54,7 @@ module.exports = {
       relationUrl: 'provider',
       foreignKey: 'code',
       field: {
-        type: 'EnyoSelect',
+        type: 'VSelect',
         fieldOptions: {
           enum: 'providers',
           trackBy: 'code',


### PR DESCRIPTION
https://trello.com/c/ztJ6nnbs/40-awesomeform-edit-mode-list-of-items-do-not-show

* There are duplicate select field type `EnyoSelect` & `FieldVSelect`, should use `FieldVSelect`